### PR TITLE
Fix local CLI runtime artifact paths and design failure events

### DIFF
--- a/src/arc-agent/agent_workflow.py
+++ b/src/arc-agent/agent_workflow.py
@@ -270,7 +270,7 @@ class ARCWorkflowManager:
                 self._mark_remaining_node_tasks_failed(queue_state, node_id)
                 self._save_processing_queue(queue_state)
                 if phase == PHASE_DESIGN:
-                    self.runtime.events.emit_requirement_state(node_id, "design", "failed")
+                    self.runtime.events.mark_design_failed(node_id)
                 if phase == PHASE_IMPLEMENT:
                     self.runtime.events.mark_test_failed(node_id)
                 await self._commit_phase_checkpoint(node_id, f"{phase}-FAILED", requirement_data)

--- a/src/arc-agent/arcbench_agent_runtime/context.py
+++ b/src/arc-agent/arcbench_agent_runtime/context.py
@@ -30,6 +30,22 @@ def _resolve_traceability_snapshot_path(traceability_db_path: Path) -> Path:
     return Path(DEFAULT_TRACEABILITY_SNAPSHOT_PATH)
 
 
+def _resolve_runner_events_path(
+    *,
+    runner_events_path: str | os.PathLike[str] | None,
+    traceability_db_path: Path,
+) -> Path:
+    if runner_events_path:
+        return Path(runner_events_path)
+    for env_key in ("ARCBENCH_RUNNER_EVENTS_PATH", "ARCBENCH_TRACEABILITY_EVENTS_PATH"):
+        env_value = os.environ.get(env_key, "").strip()
+        if env_value:
+            return Path(env_value)
+    if traceability_db_path != Path(DEFAULT_TRACEABILITY_DB_PATH) and traceability_db_path.parent:
+        return traceability_db_path.parent / "runner-events.jsonl"
+    return Path(DEFAULT_RUNNER_EVENTS_PATH)
+
+
 @dataclass(frozen=True)
 class RuntimePaths:
     project_dir: Path
@@ -48,16 +64,14 @@ class RuntimePaths:
         traceability_snapshot_path: str | os.PathLike[str] | None = None,
         demo_test_status_path: str | os.PathLike[str] | None = None,
     ) -> "RuntimePaths":
-        resolved_runner_events = Path(
-            runner_events_path
-            or os.environ.get("ARCBENCH_RUNNER_EVENTS_PATH", "").strip()
-            or os.environ.get("ARCBENCH_TRACEABILITY_EVENTS_PATH", "").strip()
-            or DEFAULT_RUNNER_EVENTS_PATH
-        )
         resolved_traceability_db = Path(
             traceability_db_path
             or os.environ.get("ARCBENCH_TRACEABILITY_DB_PATH", "").strip()
             or DEFAULT_TRACEABILITY_DB_PATH
+        )
+        resolved_runner_events = _resolve_runner_events_path(
+            runner_events_path=runner_events_path,
+            traceability_db_path=resolved_traceability_db,
         )
         resolved_project_dir = Path(
             project_dir

--- a/src/arc-agent/arcbench_agent_runtime/events.py
+++ b/src/arc-agent/arcbench_agent_runtime/events.py
@@ -34,6 +34,9 @@ class EventClient:
     def mark_design_done(self, node_id: str, message: str | None = None) -> None:
         self._emit_requirement_state(node_id, "design", "completed", message)
 
+    def mark_design_failed(self, node_id: str, message: str | None = None) -> None:
+        self._emit_requirement_state(node_id, "design", "failed", message)
+
     def mark_implementation_done(self, node_id: str, message: str | None = None) -> None:
         self._emit_requirement_state(node_id, "implement", "completed", message)
 


### PR DESCRIPTION
## Summary
- Resolve runner event artifacts under the workspace `.arc/` directory instead of the read-only ARC-Bench default `/workspace/artifacts`.
- Add `mark_design_failed()` and use it when a design phase task fails, preventing crashes from the missing `emit_requirement_state` API.

## Test plan
- [ ] Run `arc-agent` locally against `example/ticketbooking-demo` without `ARCBENCH_*` path overrides
- [ ] Confirm `.arc/runner-events.jsonl` is created under the workspace output directory
- [ ] Trigger a design-phase failure and verify compilation continues instead of crashing

Made with [Cursor](https://cursor.com)