### PR TITLE
Fix requirement upsert deleting registered tests on compilation resume

### DIFF
--- a/src/arc-agent/arcbench_agent_runtime/traceability.py
+++ b/src/arc-agent/arcbench_agent_runtime/traceability.py
@@ -340,11 +340,21 @@ class TraceabilityStore:
             raise ValueError("req_id is required")
         normalized_scenarios = scenarios or []
         with self.connection() as connection:
+            # Use ON CONFLICT DO UPDATE instead of INSERT OR REPLACE. REPLACE deletes the
+            # existing row first, which cascades and removes registered tests for req_id.
             connection.execute(
                 """
-                INSERT OR REPLACE INTO requirements (
+                INSERT INTO requirements (
                     req_id, name, description, visual_reference, scenarios, parent_id, children_ids, dependencies
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(req_id) DO UPDATE SET
+                    name = excluded.name,
+                    description = excluded.description,
+                    visual_reference = excluded.visual_reference,
+                    scenarios = excluded.scenarios,
+                    parent_id = excluded.parent_id,
+                    children_ids = excluded.children_ids,
+                    dependencies = excluded.dependencies
                 """,
                 (
                     normalized_req_id,
@@ -355,8 +365,8 @@ class TraceabilityStore:
                     str(parent_id or "").strip() or None,
                     _json_list(children_ids or []),
                     _json_list(dependencies or []),
-                    ),
-                )
+                ),
+            )
             connection.execute("DELETE FROM scenarios WHERE req_id = ?", (normalized_req_id,))
             for scenario in normalized_scenarios:
                 scenario_id = str(scenario.get("id") or scenario.get("scenario_id") or "").strip()


### PR DESCRIPTION
## Summary

Fixes a resume-time bug where registered test records disappear from `traceability.db`, causing IMPLEMENT phases to fail with *"No generated tests were found for this node"* even though test files and `node_sessions` artifacts still exist on disk.

The fix changes `upsert_requirement()` to update existing requirement rows in place instead of deleting and re-inserting them.

## Problem

### Expected behavior

When resuming an existing run with `--output-dir` (without `--clear-all`), ARC should:

1. Reuse the existing workspace, queue, and traceability database.
2. Keep previously registered test mappings in `traceability.db`.
3. Continue IMPLEMENT/TDD work against those registered tests.

### Actual behavior

On every compilation start (including resume), `compile_requirement_tree()` calls `store_all_requirement()`, which upserts every requirement node via `upsert_requirement()`.

That method used SQLite `INSERT OR REPLACE`. For an existing `req_id`, SQLite **deletes the old row and inserts a new one**.

Because `tests.req_id` has:

```sql
FOREIGN KEY(req_id) REFERENCES requirements(req_id) ON DELETE CASCADE
```

each requirement upsert silently deletes all registered tests for that node.

Symptoms observed in practice:

- Test files remain under `frontend/tests/`, `backend/tests/`, and `backend/test-e2e/`.
- `node_sessions/*.json` still contain `test_artifacts`.
- `traceability.db` loses most or all rows in the `tests` table after resume.
- IMPLEMENT fails immediately with:

  ```text
  No generated tests were found for this node. IMPLEMENT cannot complete without generated test artifacts.
  ```

## Steps to reproduce

Minimal reproduction that mirrors the resume entry path (`store_all_requirement()`):

```python
from runtime_sdk import configure_runtime
from traceability.service import store_all_requirement
import os, sqlite3, tempfile

workspace = tempfile.mkdtemp()
runtime = configure_runtime(
    project_dir=workspace,
    traceability_db_path=os.path.join(workspace, ".arc", "traceability.db"),
)
store = runtime.traceability
store.init_db()

# 1. Simulate DESIGN: register tests for completed nodes
for req_id in ("REQ-1", "REQ-3.2"):
    store.upsert_requirement(req_id=req_id, name=req_id, description="demo")
    store.upsert_test(
        test_id=f"{req_id}::Integration::001::demo",
        req_id=req_id,
        type="Integration",
        file_path=f"tests/{req_id}.test.js",
    )

# 2. Simulate resume: compile_requirement_tree() calls store_all_requirement()
store_all_requirement({
    "id": "ROOT",
    "name": "Root",
    "description": "root",
    "children": [
        {"id": "REQ-1", "name": "Auth shell", "description": "...", "children": []},
        {
            "id": "REQ-3",
            "name": "Booking",
            "description": "...",
            "children": [
                {"id": "REQ-3.2", "name": "Submit", "description": "...", "children": []},
            ],
        },
    ],
})

with sqlite3.connect(os.path.join(workspace, ".arc", "traceability.db")) as conn:
    count = conn.execute("SELECT COUNT(*) FROM tests").fetchone()[0]
print(count)  # main: 0 (bug) | fix branch: 2 (preserved)
```

### Reproduction result on `main`

```
[After DESIGN] tests in DB: total=2
  REQ-1: 1
  REQ-3.2: 1

[Resume start] calling store_all_requirement() ...

[After resume upsert] tests in DB: total=0

BUG REPRODUCED: all registered tests were cascade-deleted on resume.
```

## Root cause

- **Trigger:** `store_all_requirement()` on every compilation entry (`agent_workflow.py`).
- **Bug:** `TraceabilityStore.upsert_requirement()` used `INSERT OR REPLACE`.
- **Effect:** row replacement deletes the requirement row → `ON DELETE CASCADE` removes associated tests.

## Fix

Replace `INSERT OR REPLACE` with:

```sql
INSERT INTO requirements (...)
VALUES (...)
ON CONFLICT(req_id) DO UPDATE SET ...
```

This updates requirement metadata in place and preserves the existing row, so registered tests are not cascade-deleted.

**Scope:** one file — `src/arc-agent/arcbench_agent_runtime/traceability.py`.

No CLI/API behavior changes. No documentation updates required (internal persistence bug).

## Validation

### After fix (`fix/traceability-upsert-cascade`)

```
[After DESIGN] tests in DB: total=2
  REQ-1: 1
  REQ-3.2: 1

[Resume start] calling store_all_requirement() ...

[After resume upsert] tests in DB: total=2
  REQ-1: 1
  REQ-3.2: 1

FIX VERIFIED: registered tests preserved after resume upsert.
```

Additional unit-style check:

```python
store.upsert_requirement(req_id="REQ-1", name="Auth updated", description="desc2")
assert len(store.list_tests(req_id="REQ-1")) == 1  # passes on fix branch, fails on main
```

Checks run:

- [x] Reproduction script on `main` (confirms bug)
- [x] Same script on fix branch (confirms fix)
- [ ] Full end-to-end compilation resume (not re-run; change is isolated to DB upsert semantics)

## Related issues

None — discovered while working on resume/retry behavior locally.

## Notes for reviewers

This bug affects any resumed compilation, not only failed-node retry flows. A separate feature proposal for retrying failed nodes may follow as an issue/reference implementation; this PR is intentionally limited to the traceability upsert fix.

Made with [Cursor](https://cursor.com)